### PR TITLE
enhancement: Added Resource Group ID to outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,5 +57,6 @@ Terraform module to create the Core component of each workload, currently only i
 | <a name="output_key_vault_name"></a> [key\_vault\_name](#output\_key\_vault\_name) | n/a |
 | <a name="output_key_vault_uri"></a> [key\_vault\_uri](#output\_key\_vault\_uri) | n/a |
 | <a name="output_recovery_services_vault_id"></a> [recovery\_services\_vault\_id](#output\_recovery\_services\_vault\_id) | The Recovery Services Vault ID |
+| <a name="output_resource_group_id"></a> [resource\_group\_id](#output\_resource\_group\_id) | ID of the Resource Group created by the module |
 | <a name="output_storage_account_id"></a> [storage\_account\_id](#output\_storage\_account\_id) | n/a |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -43,3 +43,8 @@ output "recovery_services_vault_id" {
 output "storage_account_id" {
   value = var.boot_diag_storage_account != null ? module.boot_diag_storage_account[0].id : null
 }
+
+output "resource_group_id" {
+  value       = azurerm_resource_group.this.id
+  description = "ID of the Resource Group created by the module"
+}


### PR DESCRIPTION
**:bulb: Summary of the pull request**
I have added one extra output - Resource Group ID

**:hammer_and_wrench: Implementation Details**
Added the ID of the Resource Group deployed by the module to the list of Terraform outputs

**:pencil: Additional Information**
Required to support RG-level locks created in consuming deployments.
